### PR TITLE
58 buglogin logic issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,6 +95,7 @@
         <activity android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
             android:theme="@style/OssLicensesTheme"/>
         <activity android:name=".presentation.screen.main.fragment.main.settings.WebViewActivity"/>
+        <activity android:name="com.cjwjsw.runningman.presentation.screen.main.fragment.main.graph.GraphActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/cjwjsw/runningman/core/UserManager.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/UserManager.kt
@@ -1,27 +1,17 @@
 package com.cjwjsw.runningman.core
 
 import com.cjwjsw.runningman.domain.model.UserModel
-import com.cjwjsw.runningman.domain.model.UserUid
 
 
 object UserManager {
     private var instance: UserModel? = null
-    private var instances : UserUid? = null
 
     fun getInstance(): UserModel? {
         return instance
     }
 
-    fun getUidInstance():UserUid?{
-        return instances
-    }
-
-    fun setUser(nickName: String, email: String, profileImageUrl: String) {
-        instance = UserModel(nickName, email, profileImageUrl)
-    }
-
-    fun setUserUid(id : String){
-        instances = UserUid(id)
+    fun setUser(idToken: String, nickName: String, email: String, profileImageUrl: String) {
+        instance = UserModel(idToken,nickName, email, profileImageUrl)
     }
 
     fun clearUser() {

--- a/app/src/main/java/com/cjwjsw/runningman/core/UserManager.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/UserManager.kt
@@ -1,20 +1,31 @@
 package com.cjwjsw.runningman.core
 
 import com.cjwjsw.runningman.domain.model.UserModel
+import com.cjwjsw.runningman.domain.model.UserUid
 
 
 object UserManager {
     private var instance: UserModel? = null
+    private var instances : UserUid? = null
 
     fun getInstance(): UserModel? {
         return instance
     }
 
-    fun setUser(id: String, nickName: String, email: String, profileImageUrl: String) {
-        instance = UserModel(id, nickName, email, profileImageUrl)
+    fun getUidInstance():UserUid?{
+        return instances
+    }
+
+    fun setUser(nickName: String, email: String, profileImageUrl: String) {
+        instance = UserModel(nickName, email, profileImageUrl)
+    }
+
+    fun setUserUid(id : String){
+        instances = UserUid(id)
     }
 
     fun clearUser() {
         instance = null
     }
+
 }

--- a/app/src/main/java/com/cjwjsw/runningman/domain/model/UserModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/domain/model/UserModel.kt
@@ -1,11 +1,8 @@
 package com.cjwjsw.runningman.domain.model
 
 data class UserModel (
+    val idToken: String,
     val nickName: String,
     val email: String,
     val profileUrl: String,
-)
-
-data class UserUid(
-    val id : String
 )

--- a/app/src/main/java/com/cjwjsw/runningman/domain/model/UserModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/domain/model/UserModel.kt
@@ -1,8 +1,11 @@
 package com.cjwjsw.runningman.domain.model
 
 data class UserModel (
-    val id: String,
     val nickName: String,
     val email: String,
     val profileUrl: String,
+)
+
+data class UserUid(
+    val id : String
 )

--- a/app/src/main/java/com/cjwjsw/runningman/domain/usecase/FBStoreUserSignInCase.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/domain/usecase/FBStoreUserSignInCase.kt
@@ -1,34 +1,36 @@
 package com.cjwjsw.runningman.domain.usecase
 
-import android.content.Context
 import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.OAuthProvider
-import dagger.hilt.android.qualifiers.ApplicationContext
-import javax.inject.Inject
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
-class FBStoreUserSignInCase @Inject constructor(@ApplicationContext private val context: Context) {
-
+class FBStoreUserSignInCase{
     //카카오 idToken 가져오기
-    fun execute(auth: FirebaseAuth, token: String, onSuccess: (String) -> Unit, onFailure: (Exception) -> Unit) {
-        val providerId = "oidc.kakaofornative"
-        val credential = OAuthProvider.newCredentialBuilder(providerId)
-            .setIdToken(token)
-            .build()
-
-        auth.signInWithCredential(credential)
-            .addOnSuccessListener { authResult ->
-                val user = authResult.user
-                if (user != null) {
-                    Log.d("FirebaseAuth", "signInWithCredential:success${user.uid}")
-                    onSuccess(user.uid)
-                } else {
-                    onFailure(Exception("User is null"))
+    suspend fun execute(auth: FirebaseAuth, token: String, onSuccess: (String) -> Unit, onFailure: (Exception) -> Unit): Result<String> {
+        return suspendCancellableCoroutine { cont ->
+            val providerId = "oidc.kakaofornative"
+            val credential = OAuthProvider.newCredentialBuilder(providerId)
+                .setIdToken(token)
+                .build()
+            auth.signInWithCredential(credential)
+                .addOnSuccessListener { authResult ->
+                    val user = authResult.user
+                    if (user != null) {
+                        Log.d("FirebaseAuth", "signInWithCredential:success${user.uid}")
+                        onSuccess(user.uid)
+                        cont.resume(Result.success(user.uid))
+                    } else {
+                        onFailure(Exception("User is null"))
+                        cont.resume(Result.failure(Exception("User is null")))
+                    }
                 }
-            }
-            .addOnFailureListener { e ->
-                Log.e("FirebaseAuth", "signInWithCredential:failure", e)
-                onFailure(e)
-            }
+                .addOnFailureListener { e ->
+                    Log.e("FirebaseAuth", "signInWithCredential:failure", e)
+                    cont.resume(Result.failure(e))
+                    onFailure(e)
+                }
+        }
     }
 }

--- a/app/src/main/java/com/cjwjsw/runningman/domain/usecase/FBStoreUserSignInCase.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/domain/usecase/FBStoreUserSignInCase.kt
@@ -5,36 +5,30 @@ import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.OAuthProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
-import kotlin.coroutines.resume
 
 class FBStoreUserSignInCase @Inject constructor(@ApplicationContext private val context: Context) {
 
     //카카오 idToken 가져오기
-    suspend fun execute(auth: FirebaseAuth, token: String): Result<String> {
-        return suspendCancellableCoroutine { cont ->
-            val providerId = "oidc.kakaofornative"
-            val credential = OAuthProvider.newCredentialBuilder(providerId)
-                .setIdToken(token)
-                .build()
-            auth.signInWithCredential(credential)
-                .addOnSuccessListener { authResult ->
-                    val user = authResult.user
-                    if (user != null) {
-                        Log.d("FirebaseAuth", "signInWithCredential:success${user.uid}")
-                        cont.resume(Result.success(user.uid))
-                    } else {
-                        cont.resume(Result.failure(Exception("User is null")))
-                    }
+    fun execute(auth: FirebaseAuth, token: String, onSuccess: (String) -> Unit, onFailure: (Exception) -> Unit) {
+        val providerId = "oidc.kakaofornative"
+        val credential = OAuthProvider.newCredentialBuilder(providerId)
+            .setIdToken(token)
+            .build()
+
+        auth.signInWithCredential(credential)
+            .addOnSuccessListener { authResult ->
+                val user = authResult.user
+                if (user != null) {
+                    Log.d("FirebaseAuth", "signInWithCredential:success${user.uid}")
+                    onSuccess(user.uid)
+                } else {
+                    onFailure(Exception("User is null"))
                 }
-                .addOnFailureListener { e ->
-                    Log.e("FirebaseAuth", "signInWithCredential:failure", e)
-                    cont.resume(Result.failure(e))
-                }
-        }
+            }
+            .addOnFailureListener { e ->
+                Log.e("FirebaseAuth", "signInWithCredential:failure", e)
+                onFailure(e)
+            }
     }
-
-
-
 }

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginScreen.kt
@@ -156,6 +156,7 @@ class LoginScreen : AppCompatActivity() {
         binding = ActivityLoginBinding.inflate(layoutInflater)
         auth = Firebase.auth
         val isFirstLogin = UserLoginFirst.isFirstLogin(this)
+        Log.d("LoginScreen",UserLoginFirst.isFirstLogin(this).toString())
         KakaoSdk.init(this,"99180739a7bcf290c7df2a47e48e4767")
 
         setContentView(binding.root)
@@ -172,10 +173,11 @@ class LoginScreen : AppCompatActivity() {
             viewModel.kakaoLogin(this,
                 onSuccess = {
                     if(isFirstLogin){
-                        val intent = Intent(this,GenderScreen::class.java)
+
+                        val intent = Intent(this,MainActivity::class.java)
                         startActivity(intent)
                     }else{
-                        val intent = Intent(this,MainActivity::class.java)
+                        val intent = Intent(this, GenderScreen::class.java)
                         startActivity(intent)
                     }
                 },

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginScreen.kt
@@ -112,10 +112,11 @@ class LoginScreen : AppCompatActivity() {
 
     private fun handleKakaoLogedinState(loginState: LoginState.LoggedIn, auth: FirebaseAuth) {
         fbUsecase.execute(auth,loginState.token.toString(),
-            onSuccess = {
-                Log.d("LoginScreen","파이어베이스 로그인 성공${it}")
-                viewModel.setUserInfo(auth.currentUser)
 
+            onSuccess = {
+                Log.d("LoginScreen","파이어베이스 로그인 성공${auth.uid}")
+                UserManager.setUserUid(auth.uid.toString())
+                viewModel.setUserInfo(auth.currentUser)
             },
             onFailure = {
                 Log.d("LoginScreen","파이어베이스 로그인 실패${it.message}")
@@ -131,8 +132,6 @@ class LoginScreen : AppCompatActivity() {
             is LoginState.Success.Registered ->{
                 handleKakaoRegisteredState(it)
                 Log.d("LoginScreen","handleKakaoSucessState")
-                val intent = Intent(this@LoginScreen, MainActivity::class.java)
-                startActivity(intent)
             }
             is LoginState.Success.NotRegistered ->{
                 Log.d("LoginScreen","유저 정보 등록 실패")
@@ -170,12 +169,20 @@ class LoginScreen : AppCompatActivity() {
 
 
         binding.kakaoLogin.setOnClickListener {
-            if(isFirstLogin){
-                val intent = Intent(this,GenderScreen::class.java)
-                startActivity(intent)
-            }else{
-                viewModel.kakaoLogin(this,auth)
-            }
+            viewModel.kakaoLogin(this,
+                onSuccess = {
+                    if(isFirstLogin){
+                        val intent = Intent(this,GenderScreen::class.java)
+                        startActivity(intent)
+                    }else{
+                        val intent = Intent(this,MainActivity::class.java)
+                        startActivity(intent)
+                    }
+                },
+                onFailure = {
+                    Log.e("LoginScreen","로그인실패 ${it.message}")
+                })
+
         }
 
         binding.googleLogin.setOnClickListener {

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginState.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginState.kt
@@ -1,19 +1,25 @@
 package com.cjwjsw.runningman.presentation.screen.login
-sealed class State{
-        abstract val isLogin : Boolean
-        object LoggedIn : State() {
-            override val isLogin: Boolean = true
-        }
 
-        object LoggedOut : State() {
-            override val isLogin: Boolean = false
-        }
+sealed class LoginState{
+    data object Uninitialized : LoginState()
+    data class LoggedIn(
+        val token : String
+    ) : LoginState()
 
-        object Loading : State() {
-            override val isLogin: Boolean = false
-        }
+    sealed class Success: LoginState() {
 
-        object LoggedFailed : State(){
-            override val isLogin: Boolean = false
-        }
+        data class Registered(
+            val userName: String,
+            val profileImageUri: String?,
+            val email : String
+        ): Success()
+        data object NotRegistered: Success()
+
+    }
+        sealed class LoggedOut() : LoginState()
+
+        data object Loading: LoginState()
+        data class LoggedFailed(
+            val error : Exception
+        ) : LoginState()
     }

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginState.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginState.kt
@@ -9,6 +9,7 @@ sealed class LoginState{
     sealed class Success: LoginState() {
 
         data class Registered(
+            val token : String,
             val userName: String,
             val profileImageUri: String?,
             val email : String

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/main/MainFragment.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/main/MainFragment.kt
@@ -1,5 +1,6 @@
 package com.cjwjsw.runningman.presentation.screen.main.fragment.main
 
+import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -14,7 +15,6 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import android.Manifest
 import com.cjwjsw.runningman.databinding.FragmentMainBinding
 import com.cjwjsw.runningman.presentation.screen.main.fragment.main.graph.GraphActivity
 import com.cjwjsw.runningman.presentation.screen.main.fragment.main.settings.SettingsActivity
@@ -171,7 +171,7 @@ class MainFragment : Fragment() {
         if (permissionsNeeded.isNotEmpty()) {
             requestPermissionsLauncher.launch(permissionsNeeded.toTypedArray())
         } else {
-            startPedometerService()
+            //startPedometerService()
             fetchLocation()
         }
     }

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/profile/ProfileViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.cjwjsw.runningman.core.UserManager
 import com.cjwjsw.runningman.domain.model.FeedModel
-import com.cjwjsw.runningman.domain.model.UserUid
+import com.cjwjsw.runningman.domain.model.UserModel
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
@@ -29,7 +29,7 @@ class ProfileViewModel @Inject constructor(
     private val _feedArr = MutableLiveData<MutableList<FeedModel>?>()
     val feedArr: LiveData<MutableList<FeedModel>?> get() = _feedArr
 
-    private val userUid : UserUid? = UserManager.getUidInstance()
+    private val userUid : UserModel? = UserManager.getInstance()
 
     private val _uploadStatus = MutableLiveData<Boolean>()
     val uploadStatus: LiveData<Boolean> get() = _uploadStatus
@@ -41,8 +41,8 @@ class ProfileViewModel @Inject constructor(
         Log.d("ProfileViewModel", uri.toString())
     }
     fun upLoadPost(title : String, content : String){
-        val postId = userUid?.id.toString()
-        Log.d("ProfileViewModel",postId)
+        val postId = userUid?.idToken
+        Log.d("ProfileViewModel", postId!!)
         val uploadedImageUrls = mutableListOf<String>()
         val imageUris = _photoArr.value ?: return
 
@@ -89,7 +89,7 @@ class ProfileViewModel @Inject constructor(
             }
     }
     fun getUserFeed(){
-        fbsManager.collection("posts").whereEqualTo("postId",userUid?.id)
+        fbsManager.collection("posts").whereEqualTo("postId",userUid)
             .get()
             .addOnSuccessListener {document ->
                 if(document == null){

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/profile/ProfileViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.cjwjsw.runningman.core.UserManager
 import com.cjwjsw.runningman.domain.model.FeedModel
-import com.cjwjsw.runningman.domain.model.UserModel
+import com.cjwjsw.runningman.domain.model.UserUid
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
@@ -29,7 +29,7 @@ class ProfileViewModel @Inject constructor(
     private val _feedArr = MutableLiveData<MutableList<FeedModel>?>()
     val feedArr: LiveData<MutableList<FeedModel>?> get() = _feedArr
 
-    private val userUid : UserModel? = UserManager.getInstance()
+    private val userUid : UserUid? = UserManager.getUidInstance()
 
     private val _uploadStatus = MutableLiveData<Boolean>()
     val uploadStatus: LiveData<Boolean> get() = _uploadStatus

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/AgeScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/AgeScreen.kt
@@ -19,7 +19,7 @@ class AgeScreen: AppCompatActivity() {
         val gender = intent.getStringExtra("gender")
         val weight = intent.getIntExtra("weight", 0)
         val height = intent.getIntExtra("height", 0)
-        Log.d("userdata",intent.getIntExtra("weight",0).toString())
+        Log.d("userdata:weight",intent.getIntExtra("weight",0).toString())
 
         binding.nextButton.setOnClickListener {
             if (binding.ageEditText.text.isNotEmpty()) {

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
@@ -21,21 +21,20 @@ class OnBoardingEndScreen: AppCompatActivity() {
         binding = ActivityOnBoardingEndBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val user = UserManager.getUidInstance()
-        val userId = user?.id
+        val userId = UserManager.getInstance()?.idToken
 
-        Log.d("userdata",intent.getIntExtra("weight",0).toString())
+        Log.d("userdata",userId.toString())
         val gender = intent.getStringExtra("gender")
         val weight = intent.getIntExtra("weight",0)
         val height = intent.getIntExtra("height",0)
         val age = intent.getIntExtra("age", 0)
-        Log.d("userdata",userId+gender+weight+height+age)
         val intent  = Intent(this, MainActivity::class.java)
 
         binding.nextButton.setOnClickListener {
             userId?.let {
              viewModel.saveUserData(userId = userId, gender = gender ?: "", weight = weight, height = height, age = age, this)
             }
+
             if(!UserLoginFirst.isFirstLogin(this)) {
                 UserLoginFirst.setFirstLogin(this,true)
                 startActivity(intent)

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
@@ -36,11 +36,12 @@ class OnBoardingEndScreen: AppCompatActivity() {
             userId?.let {
              viewModel.saveUserData(userId = userId, gender = gender ?: "", weight = weight, height = height, age = age, this)
             }
-            if(UserLoginFirst.isFirstLogin(this)){
+            if(!UserLoginFirst.isFirstLogin(this)) {
+                UserLoginFirst.setFirstLogin(this,true)
+                startActivity(intent)
+            }else{
                 startActivity(intent)
             }
         }
-
-
     }
 }

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
@@ -23,14 +23,14 @@ class OnBoardingEndScreen: AppCompatActivity() {
 
         val user = UserManager.getUidInstance()
         val userId = user?.id
-        val intent  = Intent(this,MainActivity::class.java)
 
         Log.d("userdata",intent.getIntExtra("weight",0).toString())
-
         val gender = intent.getStringExtra("gender")
-        val weight = intent.getIntExtra("weight", 0)
+        val weight = intent.getIntExtra("weight",0)
         val height = intent.getIntExtra("height",0)
         val age = intent.getIntExtra("age", 0)
+        Log.d("userdata",userId+gender+weight+height+age)
+        val intent  = Intent(this, MainActivity::class.java)
 
         binding.nextButton.setOnClickListener {
             userId?.let {

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndScreen.kt
@@ -21,7 +21,7 @@ class OnBoardingEndScreen: AppCompatActivity() {
         binding = ActivityOnBoardingEndBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val user = UserManager.getInstance()
+        val user = UserManager.getUidInstance()
         val userId = user?.id
         val intent  = Intent(this,MainActivity::class.java)
 

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndViewModel.kt
@@ -15,16 +15,14 @@ class OnBoardingEndViewModel @Inject constructor() : ViewModel() {
 
     fun saveUserData(userId: String?, gender: String, weight: Int, height: Int, age: Int,context : Context) {
         userId?.let {
-            Log.d("OnBardEndViewModel",userId + gender + weight + height + age)
+            Log.d("OnBoardingEndViewModel",userId + gender + weight + height + age)
             val userRef = db.collection("user_info").document(userId)
-
             val userData = hashMapOf(
                 "gender" to gender,
                 "weight" to weight,
                 "height" to height,
                 "age" to age
             )
-
             userRef.set(userData)
                 .addOnSuccessListener {
                     Log.d("OnBoardingEndViewModel", "User data added successfully")

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/onboarding/onboardingend/OnBoardingEndViewModel.kt
@@ -15,6 +15,7 @@ class OnBoardingEndViewModel @Inject constructor() : ViewModel() {
 
     fun saveUserData(userId: String?, gender: String, weight: Int, height: Int, age: Int,context : Context) {
         userId?.let {
+            Log.d("OnBardEndViewModel",userId + gender + weight + height + age)
             val userRef = db.collection("user_info").document(userId)
 
             val userData = hashMapOf(


### PR DESCRIPTION
### 개요
1. 카카오 로그인 로직 변경
기존 로그인 상태관리 로직을 개선.
-> 단순히 Boolean형 값으로만 이루어지던 상태 관리를 data object에 따라 저장 및 상태관리 하게 끔 변경함
2. 유저 정보 저장 이슈 해결
-> 온보딩 페이지에서 받는 데이터를 기존엔 FB에 제대로 저장하지 못하고 있었는데 이를 해결함
3. 사용자 처음 로그인인지 아닌지 
-> SharedPreferences를 사용해서 사용자가 처음 로그인인지 아닌지에 따른 페이지 이동을 구현하였으나, 이에 맞지 않게 
페이지 이동이 이루어져 수정함. 