### PR TITLE
63 feat daily save data add

### DIFF
--- a/app/src/main/java/com/cjwjsw/runningman/core/FirestoreManager.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/FirestoreManager.kt
@@ -12,7 +12,7 @@ class FirestoreManager @Inject constructor(
 
     suspend fun saveWalk(walk: WalkModel) {
         try {
-            val userId = UserManager.getInstance()?.id ?: 1
+            val userId = UserManager.getInstance()?.idToken ?: 1
             val userDocRef = firestore.collection("walks").document(userId.toString())
 
             // userId 문서 아래에 dates 컬렉션을 만들고, 날짜를 문서 ID로 설정하여 walk 데이터를 저장

--- a/app/src/main/java/com/cjwjsw/runningman/core/UserManager.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/UserManager.kt
@@ -11,7 +11,7 @@ object UserManager {
     }
 
     fun setUser(idToken: String, nickName: String, email: String, profileImageUrl: String) {
-        instance = UserModel(idToken,nickName, email, profileImageUrl)
+        instance = UserModel(idToken, nickName, email, profileImageUrl)
     }
 
     fun clearUser() {

--- a/app/src/main/java/com/cjwjsw/runningman/core/WalkDataSingleton.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/WalkDataSingleton.kt
@@ -4,15 +4,47 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 
 object WalkDataSingleton {
-    private var _distance: Double = 0.0
-    val distance: Double
-        get() = _distance
+    private val _distance = MutableLiveData<Double>().apply { value = 0.0 }
+    val distance: LiveData<Double> = _distance
+
+    private val _stepCount = MutableLiveData<Int>().apply { value = 0 }
+    val stepCount: LiveData<Int> = _stepCount
+
+    private val _calorie = MutableLiveData<Double>().apply { value = 0.0 }
+    val calorie: LiveData<Double> = _calorie
+
+    private val _time = MutableLiveData<Long>().apply { value = 0L }
+    val time: LiveData<Long> = _time
 
     fun updateDistance(newDistance: Double) {
-        _distance = newDistance
+        _distance.postValue(newDistance)
     }
 
     fun resetDistance() {
-        _distance = 0.0
+        _distance.postValue(0.0)
+    }
+
+    fun updateStepCount(newStepCount: Int) {
+        _stepCount.postValue(newStepCount)
+    }
+
+    fun resetStepCount() {
+        _stepCount.postValue(0)
+    }
+
+    fun updateCalorie(newCalorie: Double) {
+        _calorie.postValue(newCalorie)
+    }
+
+    fun resetCalorie() {
+        _calorie.postValue(0.0)
+    }
+
+    fun updateTime(newTime: Long) {
+        _time.postValue(newTime)
+    }
+
+    fun resetTime() {
+        _time.postValue(0L)
     }
 }

--- a/app/src/main/java/com/cjwjsw/runningman/core/WalkDataSingleton.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/WalkDataSingleton.kt
@@ -4,16 +4,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 
 object WalkDataSingleton {
-    private val _distance = MutableLiveData<Double>().apply { value = 0.0 }
+    private val _distance = MutableLiveData<Double>()
     val distance: LiveData<Double> = _distance
 
-    private val _stepCount = MutableLiveData<Int>().apply { value = 0 }
+    private val _stepCount = MutableLiveData<Int>()
     val stepCount: LiveData<Int> = _stepCount
 
-    private val _calorie = MutableLiveData<Double>().apply { value = 0.0 }
+    private val _calorie = MutableLiveData<Double>()
     val calorie: LiveData<Double> = _calorie
 
-    private val _time = MutableLiveData<Long>().apply { value = 0L }
+    private val _time = MutableLiveData<Long>()
     val time: LiveData<Long> = _time
 
     fun updateDistance(newDistance: Double) {

--- a/app/src/main/java/com/cjwjsw/runningman/core/scheduleDailyDataSync.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/scheduleDailyDataSync.kt
@@ -17,28 +17,16 @@ fun scheduleDailyDataSync(context: Context) {
     // 자정까지의 시간을 계산
     val now = Calendar.getInstance()
     val target = Calendar.getInstance().apply {
-        set(Calendar.HOUR_OF_DAY, 19)
-        set(Calendar.MINUTE, 52)
+        set(Calendar.HOUR_OF_DAY, 15)
+        set(Calendar.MINUTE, 20)
         set(Calendar.SECOND, 0)
         if (before(now)) add(Calendar.DAY_OF_YEAR, 1)
     }
     val initialDelay = target.timeInMillis - now.timeInMillis
-    val currentDistance = WalkDataSingleton.distance.value ?: 0.0
-    val currentStepCount = WalkDataSingleton.stepCount.value ?: 0
-    val currentCalories = WalkDataSingleton.calorie.value ?: 0.0
-    val currentTime = WalkDataSingleton.time.value ?: 0L
-    val data: Data = workDataOf(
-        "distance" to currentDistance,
-        "stepCount" to currentStepCount,
-        "calories" to currentCalories,
-        "time" to currentTime
-    )
-
 
     // 주기적 워크 요청 설정 (매일 반복)
     val workRequest = PeriodicWorkRequestBuilder<DataSyncWorker>(1, TimeUnit.DAYS)
         .setInitialDelay(initialDelay, TimeUnit.MILLISECONDS) // 처음 시작을 자정으로 맞춤
-        .setInputData(data)
         .build()
 
     WorkManager.getInstance(context).enqueueUniquePeriodicWork(

--- a/app/src/main/java/com/cjwjsw/runningman/core/scheduleDailyDataSync.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/core/scheduleDailyDataSync.kt
@@ -17,14 +17,22 @@ fun scheduleDailyDataSync(context: Context) {
     // 자정까지의 시간을 계산
     val now = Calendar.getInstance()
     val target = Calendar.getInstance().apply {
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
+        set(Calendar.HOUR_OF_DAY, 19)
+        set(Calendar.MINUTE, 52)
         set(Calendar.SECOND, 0)
         if (before(now)) add(Calendar.DAY_OF_YEAR, 1)
     }
     val initialDelay = target.timeInMillis - now.timeInMillis
-    val currentDistance = WalkDataSingleton.distance
-    val data: Data = workDataOf("distance" to currentDistance)
+    val currentDistance = WalkDataSingleton.distance.value ?: 0.0
+    val currentStepCount = WalkDataSingleton.stepCount.value ?: 0
+    val currentCalories = WalkDataSingleton.calorie.value ?: 0.0
+    val currentTime = WalkDataSingleton.time.value ?: 0L
+    val data: Data = workDataOf(
+        "distance" to currentDistance,
+        "stepCount" to currentStepCount,
+        "calories" to currentCalories,
+        "time" to currentTime
+    )
 
 
     // 주기적 워크 요청 설정 (매일 반복)

--- a/app/src/main/java/com/cjwjsw/runningman/data/data_source/db/DailyWalk.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/data/data_source/db/DailyWalk.kt
@@ -6,5 +6,8 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "daily_walk")
 data class DailyWalk(
     @PrimaryKey val date: String,
-    val distance: Double
+    val distance: Double,
+    val stepCount: Int,
+    val calories: Double,
+    val time: Long
 )

--- a/app/src/main/java/com/cjwjsw/runningman/data/data_source/db/WalkDao.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/data/data_source/db/WalkDao.kt
@@ -19,4 +19,7 @@ interface WalkDao {
 
     @Query("SELECT COUNT(*) FROM daily_walk")
     suspend fun getWalkCount(): Int
+
+    @Query("SELECT * FROM daily_walk WHERE date BETWEEN :startDate AND :endDate")
+    suspend fun getWalksBetweenDates(startDate: String, endDate: String): List<DailyWalk>
 }

--- a/app/src/main/java/com/cjwjsw/runningman/data/repository/WalkRepositoryImpl.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/data/repository/WalkRepositoryImpl.kt
@@ -45,6 +45,10 @@ class WalkRepositoryImpl @Inject constructor(
         walkDao.getAllWalks()
     }
 
+    override suspend fun getWalksBetweenDates(startDate: String, endDate: String): List<DailyWalk> = withContext(Dispatchers.IO) {
+        walkDao.getWalksBetweenDates(startDate, endDate)
+    }
+
     override suspend fun getWalkCount(): Int = withContext(Dispatchers.IO) {
         walkDao.getWalkCount()
     }

--- a/app/src/main/java/com/cjwjsw/runningman/data/repository/WalkRepositoryImpl.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/data/repository/WalkRepositoryImpl.kt
@@ -13,24 +13,32 @@ import javax.inject.Inject
 class WalkRepositoryImpl @Inject constructor(
     private val walkDao: WalkDao,
     private val firestoreManager: FirestoreManager
-): WalkRepository {
+) : WalkRepository {
     override suspend fun getWalkByDate(date: String): DailyWalk = withContext(Dispatchers.IO) {
-        val roomWalk = walkDao.getWalkByDate(date) ?: DailyWalk(date, 0.0)
+        val roomWalk = walkDao.getWalkByDate(date) ?: DailyWalk(date, 0.0, 0, 0.0, 0L)
         // Firestore에서 데이터를 가져옴 (필요한 경우)
         val firestoreWalk = firestoreManager.getWalkByDate(date)
 
         // Firestore 데이터가 있으면 그 데이터를 사용, 아니면 Room 데이터를 반환
         firestoreWalk?.let {
-            return@withContext DailyWalk(it.date, it.distance)
+            return@withContext DailyWalk(it.date, it.distance, it.stepCount, it.calories, it.time)
         } ?: roomWalk
     }
 
-    override suspend fun insertWalk(walk: DailyWalk) = withContext(Dispatchers.IO){
+    override suspend fun insertWalk(walk: DailyWalk) = withContext(Dispatchers.IO) {
         walkDao.insertWalk(walk)
     }
 
-    override suspend fun insertFireStoreWalk(walk: DailyWalk) = withContext(Dispatchers.IO){
-        firestoreManager.saveWalk(WalkModel(walk.date, walk.distance))
+    override suspend fun insertFireStoreWalk(walk: DailyWalk) = withContext(Dispatchers.IO) {
+        firestoreManager.saveWalk(
+            WalkModel(
+                walk.date,
+                walk.distance,
+                walk.stepCount,
+                walk.calories,
+                walk.time
+            )
+        )
     }
 
     override suspend fun getAllWalks(): List<DailyWalk> = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/cjwjsw/runningman/domain/di/appModule.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/domain/di/appModule.kt
@@ -1,6 +1,7 @@
 package com.cjwjsw.runningman.domain.di
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.room.Room
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.AppGlideModule
@@ -52,6 +53,13 @@ class GlideModule : AppGlideModule() {}
 @InstallIn(SingletonComponent::class)
 object AppModule {
     private const val WEATHER_BASE_URL = "https://api.open-meteo.com/"
+    private const val PREFS_NAME = "WalkDataPrefs"
+
+    @Provides
+    @Singleton
+    fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/cjwjsw/runningman/domain/model/WalkModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/domain/model/WalkModel.kt
@@ -2,5 +2,8 @@ package com.cjwjsw.runningman.domain.model
 
 data class WalkModel (
     val date: String,
-    val distance: Double
+    val distance: Double,
+    val stepCount: Int,
+    val calories: Double,
+    val time: Long
 )

--- a/app/src/main/java/com/cjwjsw/runningman/domain/repository/WalkRepository.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/domain/repository/WalkRepository.kt
@@ -12,5 +12,7 @@ interface WalkRepository {
 
     suspend fun getAllWalks(): List<DailyWalk>
 
+    suspend fun getWalksBetweenDates(startDate: String, endDate: String): List<DailyWalk>
+
     suspend fun getWalkCount(): Int
 }

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginState2.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginState2.kt
@@ -16,6 +16,7 @@ sealed class LoginState2 {
     sealed class Success: LoginState2() {
 
         data class Registered(
+            val idToken: String,
             val userName: String,
             val profileImageUri: Uri?,
         ): Success()

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/login/LoginViewModel.kt
@@ -118,9 +118,11 @@ class LoginViewModel @Inject constructor(
     fun setUserInfo(firebaseUser: FirebaseUser?) = viewModelScope.launch{
             firebaseUser?.let{ user ->
                 myStateLiveData.value = LoginState2.Success.Registered(
+                    idToken = user.uid,
                     userName = user.displayName ?: "익명",
                     profileImageUri = user.photoUrl,
                 )
+                UserManager.setUser(user.uid, user.displayName ?: "", user.email.toString(), user.photoUrl.toString())
             }?: kotlin.run {
                 myStateLiveData.value = LoginState2.Success.NotRegistered
             }

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/main/MainViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/main/MainViewModel.kt
@@ -1,22 +1,31 @@
 package com.cjwjsw.runningman.presentation.screen.main.fragment.main
 
+import android.content.Context
+import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cjwjsw.runningman.core.WalkDataSingleton
+import com.cjwjsw.runningman.data.data_source.db.DailyWalk
 import com.cjwjsw.runningman.domain.model.weather.CurrentWeatherModel
+import com.cjwjsw.runningman.domain.repository.WalkRepository
 import com.cjwjsw.runningman.domain.repository.WeatherRepository
-import com.cjwjsw.runningman.service.PedometerService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val weatherRepository: WeatherRepository
-): ViewModel(){
+    private val weatherRepository: WeatherRepository,
+    private val walkRepository: WalkRepository,
+    private val appContext: Context
+): ViewModel() {
 
     val stepCount: LiveData<Int> = WalkDataSingleton.stepCount
     val caloriesBurned: LiveData<Double> = WalkDataSingleton.calorie
@@ -25,41 +34,63 @@ class MainViewModel @Inject constructor(
 
     private val _currentWeather = MutableLiveData<CurrentWeatherModel>()
     val currentWeather: LiveData<CurrentWeatherModel> get() = _currentWeather
-    private val _latitude = MutableLiveData<Double>()
-    private val _longitude = MutableLiveData<Double>()
 
-    private val _weatherCodeText = MutableLiveData<String>()
-    val weatherCodeText: LiveData<String> get() = _weatherCodeText
+    private val _weeklyWalks = MutableLiveData<List<DailyWalk>>()
+    val weeklyWalks: LiveData<List<DailyWalk>> get() = _weeklyWalks
+
+    private val sharedPreferences = appContext.getSharedPreferences("WalkDataPrefs", Context.MODE_PRIVATE)
+
+    init {
+        restoreLiveDataFromPreferences()
+    }
+
     fun setLocation(latitude: Double, longitude: Double) {
-        _latitude.value = latitude
-        _longitude.value = longitude
-        fetchCurrentWeather()
+        fetchCurrentWeather(latitude, longitude)
     }
 
-    fun fetchCurrentWeather() {
+    private fun fetchCurrentWeather(latitude: Double, longitude: Double) {
         viewModelScope.launch {
-            val latitude = _latitude.value ?: 0.0
-            val longitude = _longitude.value ?: 0.0
-
             val currentWeather = weatherRepository.getCurrentWeather(latitude, longitude)
-
             _currentWeather.value = currentWeather
-            _weatherCodeText.value = setWeatherCodeText(currentWeather.weather_code)
-            Log.d("currentWeather", currentWeather.toString())
+            Log.d("MainViewModel", "Current Weather: $currentWeather")
         }
     }
 
-    private fun setWeatherCodeText(weatherCode: Int): String {
-        return when (weatherCode) {
-            0 -> "맑음"
-            1, 2, 3 -> "흐림"
-            45, 48 -> "안개"
-            51, 53, 55, 56, 57 -> "이슬비"
-            61, 63, 65, 66, 67 -> "비"
-            71, 73, 75, 77 -> "눈"
-            80, 81, 82 -> "소나기"
-            95, 96, 99 -> "뇌우"
-            else -> "알 수 없는 날씨 코드"
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun fetchWeeklyWalks() {
+        viewModelScope.launch {
+            val walks = walkRepository.getWalksBetweenDates(getStartOfWeek(), getEndOfWeek())
+            _weeklyWalks.value = walks
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun getStartOfWeek(): String {
+        return LocalDate.now().with(DayOfWeek.SUNDAY).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun getEndOfWeek(): String {
+        return LocalDate.now().with(DayOfWeek.SATURDAY).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+    }
+
+    fun saveLiveDataToPreferences() {
+        sharedPreferences.edit().apply {
+            putFloat("distance", WalkDataSingleton.distance.value?.toFloat() ?: 0.0f)
+            putInt("stepCount", WalkDataSingleton.stepCount.value ?: 0)
+            putFloat("calorie", WalkDataSingleton.calorie.value?.toFloat() ?: 0.0f)
+            putLong("time", WalkDataSingleton.time.value ?: 0L)
+        }.apply()
+
+        Log.d("MainViewModel", "Data saved to SharedPreferences")
+    }
+
+    private fun restoreLiveDataFromPreferences() {
+        WalkDataSingleton.updateDistance(sharedPreferences.getFloat("distance", 0.0f).toDouble())
+        WalkDataSingleton.updateStepCount(sharedPreferences.getInt("stepCount", 0))
+        WalkDataSingleton.updateCalorie(sharedPreferences.getFloat("calorie", 0.0f).toDouble())
+        WalkDataSingleton.updateTime(sharedPreferences.getLong("time", 0L))
+
+        Log.d("MainViewModel", "Data restored from SharedPreferences")
     }
 }

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/main/MainViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/main/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cjwjsw.runningman.core.WalkDataSingleton
 import com.cjwjsw.runningman.domain.model.weather.CurrentWeatherModel
 import com.cjwjsw.runningman.domain.repository.WeatherRepository
 import com.cjwjsw.runningman.service.PedometerService
@@ -17,10 +18,10 @@ class MainViewModel @Inject constructor(
     private val weatherRepository: WeatherRepository
 ): ViewModel(){
 
-    val stepCount: LiveData<Int> = PedometerService.stepCountLiveData
-    val caloriesBurned: LiveData<Double> = PedometerService.caloriesBurnedLiveData
-    val distanceWalked: LiveData<Double> = PedometerService.distanceWalkedLiveData
-    val elapsedTime: LiveData<Long> = PedometerService.elapsedTimeLiveData
+    val stepCount: LiveData<Int> = WalkDataSingleton.stepCount
+    val caloriesBurned: LiveData<Double> = WalkDataSingleton.calorie
+    val distanceWalked: LiveData<Double> = WalkDataSingleton.distance
+    val elapsedTime: LiveData<Long> = WalkDataSingleton.time
 
     private val _currentWeather = MutableLiveData<CurrentWeatherModel>()
     val currentWeather: LiveData<CurrentWeatherModel> get() = _currentWeather

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/map/MapFragment.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/map/MapFragment.kt
@@ -68,6 +68,9 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             binding.locationText.text = address
         }
 
+        WalkDataSingleton.distance.observe(viewLifecycleOwner) { distance ->
+            updateDistanceUI(distance)
+        }
 
         binding.resetButton.setOnClickListener {
             viewModel.resetData()
@@ -108,9 +111,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 }
             }
         }
-
-        // 현재 거리 UI 업데이트
-        updateDistanceUI(WalkDataSingleton.distance)
 
         // 위치 업데이트 콜백 설정
         naverMap.addOnLocationChangeListener { location ->

--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/map/MapViewModel.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/map/MapViewModel.kt
@@ -2,18 +2,13 @@ package com.cjwjsw.runningman.presentation.screen.main.fragment.map
 
 import android.content.Context
 import android.location.Geocoder
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.cjwjsw.runningman.core.LocationTrackerManager
 import com.cjwjsw.runningman.core.WalkDataSingleton
-import com.cjwjsw.runningman.data.data_source.db.DailyWalk
-import com.cjwjsw.runningman.domain.repository.WalkRepository
 import com.naver.maps.geometry.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -21,8 +16,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MapViewModel @Inject constructor(
-    private val locationTrackerManager: LocationTrackerManager,
-    private val walkRepository: WalkRepository,
+    private val locationTrackerManager: LocationTrackerManager
 ): ViewModel() {
 
     private val _path = MutableLiveData<List<LatLng>>()
@@ -33,14 +27,6 @@ class MapViewModel @Inject constructor(
 
     private var currentDate: String = getCurrentDate()
 
-    init {
-        viewModelScope.launch {
-            val today = getCurrentDate()
-            val walk = walkRepository.getWalkByDate(today)
-            WalkDataSingleton.updateDistance(walk.distance)
-        }
-    }
-
     fun addLocation(latLng: LatLng, context: Context) {
         val today = getCurrentDate()
         if (currentDate != today) {
@@ -50,7 +36,7 @@ class MapViewModel @Inject constructor(
 
         locationTrackerManager.addLocation(latLng)
         _path.value = locationTrackerManager.getPath()
-        WalkDataSingleton.updateDistance(locationTrackerManager.getDistance())
+//        WalkDataSingleton.updateDistance(locationTrackerManager.getDistance())
         _address.value = getAddressFromLocation(latLng.latitude, latLng.longitude, context)
     }
 

--- a/app/src/main/java/com/cjwjsw/runningman/service/PedometerService.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/service/PedometerService.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.MutableLiveData
 import com.cjwjsw.runningman.R
 import com.cjwjsw.runningman.presentation.screen.main.MainActivity
 import androidx.core.app.NotificationCompat
+import com.cjwjsw.runningman.core.WalkDataSingleton
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -146,16 +147,16 @@ class PedometerService : Service(), SensorEventListener {
             }
         }
 
-        stepCount = totalSteps - initialStepCount
-        caloriesBurned = stepCount * 0.04
-        distanceWalked = stepCount * 0.762 / 1000 // km
+        val stepCount = totalSteps - initialStepCount
+        val caloriesBurned = stepCount * 0.04
+        val distanceWalked = stepCount * 0.762 / 1000 // km
 
-        stepCountLiveData.postValue(stepCount)
-        caloriesBurnedLiveData.postValue(caloriesBurned)
-        totalStepCountLiveData.postValue(totalSteps)
-        distanceWalkedLiveData.postValue(
-            BigDecimal(distanceWalked).setScale(2, RoundingMode.HALF_UP).toDouble()
-        )
+        WalkDataSingleton.updateStepCount(stepCount)
+        WalkDataSingleton.updateCalorie(caloriesBurned)
+//        WalkDataSingleton.updateDistance(
+//            BigDecimal(distanceWalked).setScale(2, RoundingMode.HALF_UP).toDouble()
+//        )
+        WalkDataSingleton.updateTime(elapsedTime)
     }
 
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {

--- a/app/src/main/java/com/cjwjsw/runningman/service/worker/DataSyncWorker.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/service/worker/DataSyncWorker.kt
@@ -1,38 +1,20 @@
 package com.cjwjsw.runningman.service.worker
 
-import android.app.Service
 import android.content.Context
-import android.content.Intent
-import android.os.IBinder
 import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.cjwjsw.runningman.core.FirestoreManager
-import com.cjwjsw.runningman.core.LocationTrackerManager
 import com.cjwjsw.runningman.core.WalkDataSingleton
 import com.cjwjsw.runningman.data.data_source.db.DailyWalk
 import com.cjwjsw.runningman.domain.model.WalkModel
 import com.cjwjsw.runningman.domain.repository.WalkRepository
-import com.cjwjsw.runningman.presentation.screen.main.fragment.map.MapViewModel
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Calendar
-import java.util.Date
 import java.util.Locale
-import javax.inject.Inject
-
-const val DISTANCE = "distance"
-const val STEPS = "stepCount"
-const val CALORIES = "calories"
-const val TIME = "time"
-
 
 @HiltWorker
 class DataSyncWorker @AssistedInject constructor(
@@ -44,11 +26,12 @@ class DataSyncWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         return try {
+            Log.d("DataSyncWorker", "Work started at: ${System.currentTimeMillis()}")
             val today = getCurrentDate()
-            val distance = inputData.getDouble(DISTANCE, 0.0)
-            val stepCount = inputData.getInt(STEPS, 0)
-            val calories = inputData.getDouble(CALORIES, 0.0)
-            val time = inputData.getLong(TIME, 0L)
+            val distance = WalkDataSingleton.distance.value ?: 0.0
+            val stepCount = WalkDataSingleton.stepCount.value ?: 0
+            val calories = WalkDataSingleton.calorie.value ?: 0.0
+            val time = WalkDataSingleton.time.value ?: 0L
 
             // Room에 데이터 저장
             val dailyWalk = DailyWalk(
@@ -58,6 +41,8 @@ class DataSyncWorker @AssistedInject constructor(
                 calories = calories,
                 time = time
             )
+            Log.d("DataSyncWorker", "DailyWalk Data: $dailyWalk")
+
             walkRepository.insertWalk(dailyWalk)
 
             // Firestore에 저장

--- a/app/src/main/java/com/cjwjsw/runningman/service/worker/DataSyncWorker.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/service/worker/DataSyncWorker.kt
@@ -29,6 +29,10 @@ import java.util.Locale
 import javax.inject.Inject
 
 const val DISTANCE = "distance"
+const val STEPS = "stepCount"
+const val CALORIES = "calories"
+const val TIME = "time"
+
 
 @HiltWorker
 class DataSyncWorker @AssistedInject constructor(
@@ -42,14 +46,34 @@ class DataSyncWorker @AssistedInject constructor(
         return try {
             val today = getCurrentDate()
             val distance = inputData.getDouble(DISTANCE, 0.0)
+            val stepCount = inputData.getInt(STEPS, 0)
+            val calories = inputData.getDouble(CALORIES, 0.0)
+            val time = inputData.getLong(TIME, 0L)
 
             // Room에 데이터 저장
-            val dailyWalk = DailyWalk(date = today, distance = distance)
+            val dailyWalk = DailyWalk(
+                date = today,
+                distance = distance,
+                stepCount = stepCount,
+                calories = calories,
+                time = time
+            )
             walkRepository.insertWalk(dailyWalk)
 
             // Firestore에 저장
-            val walk = walkRepository.getWalkByDate(today)
-            firestoreManager.saveWalk(WalkModel(date = today, distance = walk.distance))
+            firestoreManager.saveWalk(WalkModel(
+                date = today,
+                distance = distance,
+                stepCount = stepCount,
+                calories = calories,
+                time = time
+            ))
+
+            //저장 후 데이터 초기화
+            WalkDataSingleton.resetDistance()
+            WalkDataSingleton.resetStepCount()
+            WalkDataSingleton.resetCalorie()
+            WalkDataSingleton.resetTime()
 
             Result.success()
         } catch (e: Exception) {


### PR DESCRIPTION
### 기능추가
+ 매일 자정 걸음 수, 칼로리, 걸음 거리, 시간 데이터를 firestore와 room에 저장
+ HomeFragment에 위치한 7개 커스텀 프로그레스바에 이번주 걸음 수에 맞게 그래프 띄우기

### 테스트 결과
+ Worker에 걸음 데이터가 잘 전달되고, 특정 시간에 Worker 작업을 실행하는데 문제없음.