### PR TITLE
[FIX] Fix Feed Profile Image

### DIFF
--- a/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/social/FeedDetailScreen.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/presentation/screen/main/fragment/social/FeedDetailScreen.kt
@@ -30,7 +30,7 @@ class FeedDetailScreen: AppCompatActivity() {
         setContentView(binding.root)
         uid = intent.getStringExtra("UID").toString()
         val image = intent.getStringArrayListExtra("URL")
-        profileImg = userData?.profileUrl!!
+        profileImg = intent.getStringExtra("profileUrl").toString()
         feedTitle = intent.getStringExtra("title").toString()
         IL = intent.getBooleanExtra("isLiked",false) // 좋아요 눌렀는지 아닌지
         Lc = intent.getIntExtra("likedCount",0) // 좋아요 개수
@@ -43,7 +43,7 @@ class FeedDetailScreen: AppCompatActivity() {
         binding.indicator.setViewPager(binding.feedImgViewPager)
         binding.title.text = feedTitle
         binding.likedCountText.text = "${Lc}명이 좋아합니다"
-        userNumber = userData.userNumber
+        userNumber = userData?.userNumber ?: ""
 
         isLikedImg(IL)
         loadProfileImg()


### PR DESCRIPTION
# 개요
현재 소셜에서 보이는 피드들의 프사가 전부 로그인한 사용자의 프로필 사진으로 나옴
#테스트
FB에 저장되어있는 피드 정보에 등록된 이미지로 프로필 사진 변경 확인