### PR TITLE
[FIX] PedometerService 걸음 수 -단위로 찍히는 오류 수정

### DIFF
--- a/app/src/main/java/com/cjwjsw/runningman/service/PedometerService.kt
+++ b/app/src/main/java/com/cjwjsw/runningman/service/PedometerService.kt
@@ -137,6 +137,8 @@ class PedometerService : Service(), SensorEventListener {
         val calendar = Calendar.getInstance()
         val currentDay = calendar.get(Calendar.DAY_OF_YEAR)
 
+        Log.d("PedometerService", "Total Steps: $totalSteps, Initial Step Count: $initialStepCount")
+
         if (currentDay != lastCheckedDay) {
             initialStepCount = totalSteps
             lastCheckedDay = currentDay
@@ -147,7 +149,14 @@ class PedometerService : Service(), SensorEventListener {
             }
         }
 
+        // totalSteps 값이 초기화되었거나 예상보다 작을 경우, 초기 걸음 수 재설정
+        if (totalSteps < initialStepCount || totalSteps < 1000) {
+            initialStepCount = totalSteps
+            sharedPreferences.edit().putInt("initialStepCount", initialStepCount).apply()
+        }
+
         val stepCount = totalSteps - initialStepCount
+        Log.d("PedometerService", "Calculated Step Count: $stepCount")
 
         WalkDataSingleton.updateStepCount(stepCount)
     }


### PR DESCRIPTION
## 오류 수정
+ 걸음 수가 -단위로 찍히는 오류 수정
+ 폰 재부팅 시 만보기 센서가 초기화 되는 현상이 있음. 따라서 initialStepCount값이 totalSteps값보다 월등히 커져서 -4698이 뜨는 현상이 발생했음.
+ 따라서 initialStepCount값과 totalSteps값의 차이가 크면 initialStepCount값을 초기화하는 방향으로 수정.

## 테스트 결과
이상 없음